### PR TITLE
打点・得点・盗塁・エラーもマイナスを選べないようにする #44

### DIFF
--- a/fuel/app/views/game/batter.twig
+++ b/fuel/app/views/game/batter.twig
@@ -56,10 +56,10 @@
 <td class="shikyuu">{{seiseki.shikyuu}}</td>
 <td class="gida">{{seiseki.gida}}</td>
 <td class="gihi">{{seiseki.gihi}}</td>
-<td class="daten"><input type="number" class="form-control" value="{{seiseki.daten}}"></td>
-<td class="tokuten"><input type="number" class="form-control" value="{{seiseki.tokuten}}"></td>
-<td class="steal"><input type="number" class="form-control" value="{{seiseki.steal}}"></td>
-<td class="error"><input type="number" class="form-control" value="{{seiseki.error}}"></td>
+<td class="daten"><input type="number" class="form-control" value="{{seiseki.daten}}" min="0"></td>
+<td class="tokuten"><input type="number" class="form-control" value="{{seiseki.tokuten}}" min="0"></td>
+<td class="steal"><input type="number" class="form-control" value="{{seiseki.steal}}" min="0"></td>
+<td class="error"><input type="number" class="form-control" value="{{seiseki.error}}" min="0"></td>
 </tr>
 
 <tr class="disable detail detail-{{loop.index}}">


### PR DESCRIPTION
野手成績登録画面の打点・得点・盗塁・エラーもマイナスにならないように修正。
inputタグにmin="0"を追加（4カ所）
