### PR TITLE
Change the organization for hadolint in Github actions

### DIFF
--- a/.github/workflows/hadolint.yaml
+++ b/.github/workflows/hadolint.yaml
@@ -12,14 +12,14 @@ jobs:
       # see: https://github.com/hadolint/hadolint#configure
       # see: https://hub.docker.com/r/hadolint/hadolint
       # see: https://github.com/marketplace/actions/hadolint-action
-      - uses: brpaz/hadolint-action@v1.2.1
+      - uses: hadolint/hadolint-action@v1.5.0
         with:
           dockerfile: ./docker/web/Dockerfile
 
-      - uses: brpaz/hadolint-action@v1.2.1
+      - uses: hadolint/hadolint-action@v1.5.0
         with:
           dockerfile: ./docker/web/Dockerfile.legacy
 
-      - uses: brpaz/hadolint-action@v1.2.1
+      - uses: hadolint/hadolint-action@v1.5.0
         with:
           dockerfile: ./docker/heroku/Dockerfile.heroku


### PR DESCRIPTION
- [Hadolint Action · Actions · GitHub Marketplace](https://github.com/marketplace/actions/hadolint-action)
- [hadolint/hadolint\-action: GitHub action for Hadolint, A Dockerfile linting tool](https://github.com/hadolint/hadolint-action)